### PR TITLE
Don't show vertical scrollbar if it's not necessary

### DIFF
--- a/book/styles.css
+++ b/book/styles.css
@@ -4,5 +4,5 @@ svg text {
 
 .scroll {
   width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }


### PR DESCRIPTION
Why force a scrollbar if you don't need it like here?

![image](https://cloud.githubusercontent.com/assets/7819991/16654321/8b483b24-4455-11e6-8fa3-8715c75cebf8.png)
